### PR TITLE
Escape dynamic values in OPDS XML feeds

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,6 +67,10 @@ pub fn create_app(config: &'static Config) -> AppState {
         .collect();
 
     tera.add_raw_templates(templates).expect("Failed to add templates");
+    // Embedded template names end in `.xml.tera`, which Tera does not
+    // auto-escape by default. Escape dynamic values so Calibre metadata such
+    // as ampersands cannot produce malformed OPDS XML.
+    tera.autoescape_on(vec![".html", ".htm", ".xml", ".xml.tera"]);
     tera.register_filter("format_to_mime", format_to_mime_filter);
 
     AppState {

--- a/tests/orca_test.rs
+++ b/tests/orca_test.rs
@@ -86,6 +86,33 @@ async fn list_books() {
 }
 
 #[test]
+async fn book_metadata_is_xml_escaped() {
+    let state = create_app(&TEST_HTTP_CONFIG);
+    let mut context = tera::Context::new();
+    context.insert("config", &state.config);
+    context.insert("lib", "library");
+    context.insert("books", &serde_json::json!([{
+        "id": 999,
+        "title": "Fish & Chips <Special>",
+        "pubdate": "2026-01-01T00:00:00+00:00",
+        "synopsis": "Science fact & science fiction",
+        "author_id": 1,
+        "author_name": "A & B",
+        "formats": ["epub"]
+    }]));
+
+    let content = state
+        .templates
+        .render("books.xml.tera", &context)
+        .expect("Failed to render books template");
+
+    assert!(content.contains("Fish &amp; Chips &lt;Special&gt;"));
+    assert!(content.contains("Science fact &amp; science fiction"));
+    assert!(content.contains("A &amp; B"));
+    assert_eq!(count_items(&content), 1);
+}
+
+#[test]
 async fn list_authors() {
     let app = setup(Http).await;
     let credentials = BASE64.encode("alice:secretpassword");


### PR DESCRIPTION
Summary

- Enables Tera auto-escaping for embedded `.xml.tera` templates.
- Prevents Calibre metadata containing `&`, `<`, or `>` from producing malformed OPDS XML.
- Adds a regression test covering special characters in book titles, synopses, and author names.

### Problem

ORCA currently emits dynamic Calibre metadata without XML escaping. For example, a synopsis containing:

```text
science fact & science fiction
```

is rendered with a raw ampersand inside `<content>`. OPDS clients then reject the `/books` feed with an error such as:

```text
ill-formed document: entity or character reference not closed:
`;` not found before end of input
```

### Fix

Tera does not automatically escape these templates because their filenames end in `.xml.tera`, rather than `.xml`. This change adds `.xml.tera` to the configured auto-escape suffixes so all dynamic values in OPDS templates are escaped.

### Testing

- Added a regression test with special characters in a title, synopsis, and author name.
- Verified that the rendered values contain valid XML entities.
- Verified that the resulting feed can be parsed by `quick_xml`.
- `cargo test`: **42 passed, 0 failed**.